### PR TITLE
fix: Prevent panic caused by subtracting with overflow

### DIFF
--- a/rups/src/blocking/mod.rs
+++ b/rups/src/blocking/mod.rs
@@ -138,7 +138,7 @@ impl TcpConnection {
         if debug {
             eprint!("DEBUG <- {}", raw);
         }
-        raw = raw[..raw.len() - 1].to_string(); // Strip off \n
+        raw = raw.trim_end_matches('\n').to_string(); // Strip off \n
 
         // Parse args by splitting whitespace, minding quotes for args with multiple words
         let args = shell_words::split(&raw)

--- a/rups/src/tokio/mod.rs
+++ b/rups/src/tokio/mod.rs
@@ -144,7 +144,7 @@ impl TcpConnection {
         if debug {
             eprint!("DEBUG <- {}", raw);
         }
-        raw = raw[..raw.len() - 1].to_string(); // Strip off \n
+        raw = raw.trim_end_matches('\n').to_string(); // Strip off \n
 
         // Parse args by splitting whitespace, minding quotes for args with multiple words
         let args = shell_words::split(&raw)


### PR DESCRIPTION
This pull request fixes a bug that caused panic when trying to subtract the last character from an empty string. This could happen if there was a lost connection and the returned string was empty. I experienced this when running `rups` for a longer period of time on Wi-Fi.

I verified the fix by simulating packet loss with `nftables` on Linux.